### PR TITLE
feat: Add three-site box mode for climate drivers

### DIFF
--- a/forecast_kpx/README.md
+++ b/forecast_kpx/README.md
@@ -248,6 +248,30 @@ For interactive analysis, use the notebooks:
 - **Importance**: Feature importance for Random Forest models
 - **Correlation maps**: Spatial correlation patterns
 
+## Three-Site Box Mode (Area-Weighted + Capacity-Weighted)
+
+This mode aligns climate drivers with the physical aggregation of KPX generation across three named PV sites:
+
+- Per-site boxes: One fixed-size square box (configurable half-side, default 0.5°) around each site:
+  - `안산연성정수장태양광`
+  - `세종시폐기물내립장태양광`
+  - `영암에프원태양광`
+- Within each box, daily climate variables are computed as area-weighted means (cos(latitude) weights). Intensive variables are averaged (e.g., `ssrd_sum`, `t2m`, `wind10`, `tcc`).
+- Cross-site combine: Per-site series are combined to a single daily climate driver using capacity-weighted mean (weights from KPX `solarenergy2.csv`; falls back to equal if unavailable).
+- Two forecasting tracks are supported for the combined driver:
+  - Climate-total: capacity-weighted daily means (no detrending)
+  - Climate-anom: detrended/DOY anomalies using the same exclusion window used for generation anomalies
+
+Outputs added:
+- `outputs/features/local/boxed_features.parquet` (both total and anomaly columns)
+- `outputs/correlation_maps/boxed_correlation_summary.csv`
+- `outputs/plots/boxed_corr_[VAR].png`
+
+Integration points (no CLI changes):
+- Correlations: Series-level correlations between generation anomaly and boxed climate anomalies run before spatial maps.
+- Features: Local feature set now includes boxed drivers (total + anomaly) and their lags alongside existing calendar/energy lags.
+- Models: Both baseline and RF consume the augmented local features; extended features path remains unchanged.
+
 ## Memory Management
 
 The code is optimized for Google Colab with:

--- a/forecast_kpx/colab_demo.py
+++ b/forecast_kpx/colab_demo.py
@@ -16,7 +16,7 @@ sys.path.append('src')
 # Import custom modules
 from io_load import load_kpx, load_kpx_multi_file, create_korea_and_extended_datasets
 from anomalies import daily_doy_anom_detrended, create_targets
-from corr_maps import create_correlation_maps
+from corr_maps import create_correlation_maps, correlate_boxed_series
 from features import create_feature_sets, save_features
 from models_baseline import run_baseline_models
 from models_rf_grid import run_random_forest_models
@@ -178,6 +178,15 @@ def run_demo():
         )
         print(f"✓ Correlation maps created")
         print(f"  Pearson range: {pearson_corr.min().values:.3f} to {pearson_corr.max().values:.3f}")
+        # Boxed series correlations (with synthetic capacities)
+        from io_load import build_boxed_climate_series
+        raw_boxed, anom_boxed = build_boxed_climate_series(ds_korea, {
+            'timeframe': config['timeframe'],
+            'sites': {'box_half_deg': 0.5},
+            'data': {'kpx_original': 'data/solarenergy2.csv'}
+        })
+        correlate_boxed_series(anom_series, anom_boxed)
+        print("✓ Boxed series correlation summary created")
     except Exception as e:
         print(f"✗ Correlation analysis failed: {e}")
     


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add three-site box mode for climate drivers

- Implement capacity-weighted climate aggregation across sites

- Create area-weighted means within site boxes

- Add boxed series correlation analysis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ERA5 Climate Data"] --> B["Site Box Selection"]
  B --> C["Area-Weighted Means"]
  C --> D["Capacity-Weighted Combine"]
  D --> E["Boxed Climate Series"]
  E --> F["Correlation Analysis"]
  E --> G["Feature Integration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>io_load.py</strong><dd><code>Core boxed climate series implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/src/io_load.py

<ul><li>Add three-site box selection and area-weighted aggregation functions<br> <li> Implement capacity-weighted combining across sites<br> <li> Create <code>build_boxed_climate_series()</code> main function<br> <li> Add site definitions and capacity loading from KPX data</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-4419c388e96db43fd004342ba8c00ce0ba344a402b1925a29b193a76e37e3fb3">+210/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>corr_maps.py</strong><dd><code>Boxed series correlation analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/src/corr_maps.py

<ul><li>Add <code>correlate_boxed_series()</code> function for series-to-series <br>correlations<br> <li> Generate scatter plots and CSV summary for boxed correlations<br> <li> Compute Pearson and Spearman correlations between generation and <br>climate anomalies</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-27b35af0e5f128ce6fce10d09747200f716869fea36efc4c995dfe42ada1d140">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>features.py</strong><dd><code>Boxed climate feature integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/src/features.py

<ul><li>Add <code>_create_boxed_climate_features()</code> function<br> <li> Integrate boxed climate drivers into local feature set<br> <li> Include boxed variables in lag feature creation<br> <li> Save boxed features as parquet artifact</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-05ae3fab72e6695dd9114c9019da12fcbef97df5b1f09b4fff809fab61fcd147">+41/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Main pipeline integration for boxed mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/main.py

<ul><li>Add boxed series correlation step to analysis pipeline<br> <li> Import <code>build_boxed_climate_series</code> and <code>correlate_boxed_series</code><br> <li> Pass <code>ds_korea</code> to correlation analysis function</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-69e545662e1864c81464db7696fa5414c667bdd1ea128ce811435bcdf30995f8">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>colab_demo.py</strong><dd><code>Demo integration for boxed climate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/colab_demo.py

<ul><li>Add demonstration of boxed series correlation functionality<br> <li> Import <code>correlate_boxed_series</code> and <code>build_boxed_climate_series</code><br> <li> Create synthetic example with boxed climate analysis</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-8febe4a81b9957d6494fb7298b04ce71fa6d56a8bca6cc288c15b8a95a922d8d">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_installation.py</strong><dd><code>Testing for boxed climate features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/test_installation.py

<ul><li>Add smoke test for boxed climate series functionality<br> <li> Test <code>build_boxed_climate_series()</code> with minimal config<br> <li> Verify boxed correlation summary generation</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-ccfd8c5f5bdbce895d81438422765f20507e7b29fc86301d906adeaa7de93e32">+30/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation for boxed climate mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forecast_kpx/README.md

<ul><li>Add comprehensive documentation for three-site box mode<br> <li> Explain area-weighted and capacity-weighted aggregation<br> <li> Document output files and integration points</ul>


</details>


  </td>
  <td><a href="https://github.com/emrosecr/forecasting_solar/pull/2/files#diff-946e985eb149aae38a4298ab1bf175df60ba38fa2ca989237135aa6aa8aeea73">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

